### PR TITLE
Issues/187 Refactor: 讓伺服器優先選取 zeabur 而非本地

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -26,7 +26,6 @@ const allowedOrigins = [
   'https://tripmate.zeabur.app',
   'https://tripmate-backend.zeabur.app',
   'https://tripmate-mayoyo.com',
-  'https://tripmate.vercel.app',
   'http://localhost:5173',
   'http://localhost:5174',
   'http://127.0.0.1:5173',


### PR DESCRIPTION
為避免伺服器連線到本地 localhost ，將 server.js 改優先 Zeabur 
`(import.meta.env.DEV ? 'http://localhost:3000' : 'https://tripmate-backend.zeabur.app')`