### PR TITLE
issues/194 chore: 優化首頁 SEO Meta 標籤與修復 Favicon 顯示問題

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,16 +2,33 @@
 <html lang="zh-TW">
   <head>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+    <title>TripMate - 找旅伴、行程規劃與旅遊社群平台</title>
+    <meta
+      name="description"
+      content="TripMate 致力於打造一個結合旅遊論壇、行程規劃、旅伴配對與旅遊交友的一站式平台。透過智慧性格測驗與獨特的護照系統，讓旅行不再孤單，下一站，我們一起出發。"
+    />
+    <meta
+      name="keywords"
+      content="TripMate, 馬遊友, 旅遊社群, 找旅伴, 旅伴配對, 行程規劃, 旅遊論壇, 旅遊交友, 自助旅行, 旅遊性格測驗, 行程市集"
+    />
+    <meta name="author" content="TripMate Team" />
+
+    <meta property="og:title" content="TripMate - 旅遊社群平台" />
+    <meta
+      property="og:description"
+      content="讓旅行不再孤單，下一站，我們一起出發。加入馬遊友，尋找最適合你的旅行夥伴！"
+    />
+    <meta property="og:type" content="website" />
 
     <link
       rel="icon"
-      href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🐱</text></svg>"
+      type="image/svg+xml"
+      href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E🐱%3C/text%3E%3C/svg%3E"
     />
 
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>TripMate - 旅遊社群平台</title>
     <style>
-      /* 所有的@import引用要放在最前面 */
       @import url('https://fonts.googleapis.com/css2?family=Chiron+Sung+HK:ital,wght@0,200..900;1,200..900&family=Momo+Signature&family=Momo+Trust+Sans:wght@200..800&family=Noto+Sans+JP:wght@100..900&family=Shippori+Antique&display=swap');
 
       @font-face {
@@ -28,16 +45,4 @@
     <div id="app"></div>
     <script type="module" src="/src/main.js"></script>
   </body>
-  <style>
-    /* 所有的@import引用要放在最前面 */
-    @import url('https://fonts.googleapis.com/css2?family=Chiron+Sung+HK:ital,wght@0,200..900;1,200..900&family=Momo+Signature&family=Momo+Trust+Sans:wght@200..800&family=Noto+Sans+JP:wght@100..900&family=Shippori+Antique&display=swap');
-    @font-face {
-      font-family: 'Cubic 11';
-      src: url('https://cdn.jsdelivr.net/gh/ACh-K/Cubic-11@v1.1.3/fonts/web/Cubic_11.woff2')
-        format('woff2');
-      font-weight: normal;
-      font-style: normal;
-      font-display: swap;
-    }
-  </style>
 </html>


### PR DESCRIPTION
本次更新主要針對 index.html 進行 SEO (搜尋引擎優化) 設定，並修復了 Favicon (小貓圖示) 在部分瀏覽器可能無法正確顯示的問題，同時清理了 HTML 結構中的冗餘代碼。

### 🚀 變更內容 (Changes)
**新增 SEO Meta Tags：**
根據 AboutUsPage.vue 中的產品核心價值，新增了 description 與 keywords。

**關鍵字**包含：「TripMate、馬遊友、找旅伴、行程規劃、旅遊交友」等，提升搜尋能見度。

**新增 Open Graph (OG) 標籤：**
設定了 og:title 與 og:description，優化連結在社群媒體 (Facebook, LINE) 分享時的預覽效果。

**修復 Favicon 顯示問題：**
將原本未經編碼的 SVG 字串 (<svg>...) 改為 URL Encoded 格式 (%3Csvg...)，確保小貓 Icon (🐱) 能在所有瀏覽器中穩定顯示。

**代碼清理 (Refactor)：**
移除了原本誤至於 </body> 標籤後方的重複 <style> 區塊，修正 HTML 結構錯誤。
